### PR TITLE
feat[GEN-53]: Implementada a visualização de colunas e tarefas por projeto referenciado pelo id do usuário

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "java.debug.settings.onBuildFailureProceed": true,
-    "java.configuration.updateBuildConfiguration": "interactive",
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/taskmngr-backend/.idea/.gitignore
+++ b/taskmngr-backend/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/taskmngr-backend/.idea/copilot.data.migration.agent.xml
+++ b/taskmngr-backend/.idea/copilot.data.migration.agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/taskmngr-backend/.idea/copilot.data.migration.ask.xml
+++ b/taskmngr-backend/.idea/copilot.data.migration.ask.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AskMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/taskmngr-backend/.idea/copilot.data.migration.edit.xml
+++ b/taskmngr-backend/.idea/copilot.data.migration.edit.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="EditMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/taskmngr-backend/.idea/misc.xml
+++ b/taskmngr-backend/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/taskmngr-backend/.idea/modules.xml
+++ b/taskmngr-backend/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/taskmngr-backend.iml" filepath="$PROJECT_DIR$/.idea/taskmngr-backend.iml" />
+    </modules>
+  </component>
+</project>

--- a/taskmngr-backend/.idea/taskmngr-backend.iml
+++ b/taskmngr-backend/.idea/taskmngr-backend.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/taskmngr-backend/.idea/vcs.xml
+++ b/taskmngr-backend/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/controller/ColunaController.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/controller/ColunaController.java
@@ -22,13 +22,18 @@ import jakarta.validation.Valid;
 @RestController
 @RequestMapping("/colunas")
 public class ColunaController {
-    
+
     @Autowired
     private ColunaService colunaService;
 
-    @GetMapping
-     public ResponseEntity<List<ColunaDTO>> listarColunas() {
-        return ResponseEntity.ok(colunaService.listarTodas());
+    // @GetMapping
+    //  public ResponseEntity<List<ColunaDTO>> listarColunas() {
+    //     return ResponseEntity.ok(colunaService.listarTodas());
+    // }
+
+    @GetMapping("/por-projeto/{projId}")
+    public ResponseEntity<List<ColunaDTO>> listarColunasPorProjeto(@PathVariable String projId) {
+        return ResponseEntity.ok(colunaService.listarPorProjeto(projId));
     }
 
     @PostMapping("/cadastrar")
@@ -44,7 +49,7 @@ public class ColunaController {
     }
 
     @DeleteMapping("/deletar/{id}")
-    public ResponseEntity<Void> deletarColuna(@PathVariable String id) { // id é String
+    public ResponseEntity<Void> deletarColuna(@PathVariable String id) {
         colunaService.deletarColuna(id);
         return ResponseEntity.noContent().build();
     }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/controller/TarefaController.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/controller/TarefaController.java
@@ -3,14 +3,18 @@ package com.taskmanager.taskmngr_backend.controller;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus; // pra retornar erro/sucesso
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*; //importa todas as annotations do spring de 1 vez
+import org.springframework.security.core.annotation.AuthenticationPrincipal; // <-- IMPORT ADICIONADO
+import org.springframework.web.bind.annotation.*;
 
 import com.taskmanager.taskmngr_backend.exceptions.personalizados.tarefas.InvalidTaskDataException;
 import com.taskmanager.taskmngr_backend.model.AdicionadorLinkTarefa;
+import com.taskmanager.taskmngr_backend.model.ProjetoModel; // <-- IMPORT ADICIONADO
 import com.taskmanager.taskmngr_backend.model.TarefaModel;
+import com.taskmanager.taskmngr_backend.model.UsuarioModel; // <-- IMPORT ADICIONADO
 import com.taskmanager.taskmngr_backend.model.dto.TarefaDTO;
+import com.taskmanager.taskmngr_backend.service.ProjetoService; // <-- IMPORT ADICIONADO
 import com.taskmanager.taskmngr_backend.service.TarefaConverterService;
 import com.taskmanager.taskmngr_backend.service.TarefaService;
 
@@ -22,11 +26,28 @@ public class TarefaController {
 
     @Autowired
     private TarefaService tarefaService;
+
+    @Autowired
+    private ProjetoService projetoService;
+
     @Autowired
     private AdicionadorLinkTarefa adicionadorLink;
+
     @Autowired
     private TarefaConverterService tarefaConverterService;
 
+    @GetMapping("/listar-por-usuario")
+    public ResponseEntity<List<TarefaDTO>> listarTarefasDoUsuario(@AuthenticationPrincipal UsuarioModel usuario) {
+        List<ProjetoModel> projetosDoUsuario = projetoService.listarPorUsuario(usuario);
+
+        List<TarefaModel> tarefas = tarefaService.listarPorProjetos(projetosDoUsuario);
+
+        List<TarefaDTO> dtos = tarefas.stream()
+                .map(tarefaConverterService::modelParaDto)
+                .toList();
+        adicionadorLink.adicionarLink(dtos);
+        return ResponseEntity.ok(dtos);
+    }
 
     @GetMapping("/{tar_id}")
     public ResponseEntity<TarefaDTO> buscarPorId(@PathVariable String tar_id) {
@@ -38,57 +59,61 @@ public class TarefaController {
         } else {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
-    } //caso precise buscar por id
+    }
+
+    @GetMapping("/por-projeto/{projId}")
+    public ResponseEntity<List<TarefaDTO>> listarTarefasPorProjeto(@PathVariable String projId) {
+        List<TarefaModel> tarefas = tarefaService.listarPorProjetoUnico(projId);
+        List<TarefaDTO> dtos = tarefas.stream()
+                .map(tarefaConverterService::modelParaDto)
+                .toList();
+        adicionadorLink.adicionarLink(dtos);
+        return ResponseEntity.ok(dtos);
+    }
 
     @GetMapping("/listar")
     public ResponseEntity<List<TarefaDTO>> listarTarefa() {
         List<TarefaModel> tarefas = tarefaService.listarTodas();
         List<TarefaDTO> dtos = tarefas.stream()
-            .map(tarefaConverterService::modelParaDto)
-            .toList();
+                .map(tarefaConverterService::modelParaDto)
+                .toList();
         adicionadorLink.adicionarLink(dtos);
         return ResponseEntity.ok(dtos);
     }
 
     @PostMapping("/cadastrar")
-    public ResponseEntity<?> cadastrarTarefa(@RequestBody TarefaDTO dto) {
-        // Validar dados obrigatórios
+    public ResponseEntity<?> cadastrarTarefa(@RequestBody TarefaDTO dto, @AuthenticationPrincipal UsuarioModel usuarioLogado) {
         if (dto.getTar_titulo() == null || dto.getTar_titulo().trim().isEmpty()) {
             throw new InvalidTaskDataException("Dados da tarefa inválidos", "Título é obrigatório");
         }
-        
         if (dto.getTar_descricao() == null || dto.getTar_descricao().trim().isEmpty()) {
             throw new InvalidTaskDataException("Dados da tarefa inválidos", "Descrição é obrigatória");
         }
-        
-        // validações adicionais
         if (dto.getTar_status() == null || dto.getTar_status().trim().isEmpty()) {
             throw new InvalidTaskDataException("Dados da tarefa inválidos", "Status é obrigatório");
         }
-        
         if (dto.getTar_prioridade() == null || dto.getTar_prioridade().trim().isEmpty()) {
             throw new InvalidTaskDataException("Dados da tarefa inválidos", "Prioridade é obrigatória");
-        } //dados obrigatorios que toda tarefa tem que ter: titulo descricao status e prioridade
-        
+        }
         TarefaModel tarefa = tarefaConverterService.dtoParaModel(dto);
+        if (usuarioLogado != null) {
+            tarefa.setUsu_id(usuarioLogado.getUsu_id());
+            tarefa.setUsu_nome(usuarioLogado.getUsu_nome());
+        }
         tarefaService.salvar(tarefa);
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body("Tarefa cadastrada com sucesso!");
+                .body("Tarefa cadastrada com sucesso!");
     }
 
     @PutMapping("/atualizar/{tar_id}")
-    public ResponseEntity<String> atualizarTarefa(@PathVariable String tar_id, @RequestBody TarefaDTO dto) {
-        // Adicionar as mesmas validações aqui também
+    public ResponseEntity<String> atualizarTarefa(@PathVariable String tar_id, @RequestBody TarefaDTO dto, @AuthenticationPrincipal UsuarioModel usuarioLogado) { // Adicionado o usuarioLogado
         if (dto.getTar_titulo() == null || dto.getTar_titulo().trim().isEmpty()) {
             throw new InvalidTaskDataException("Dados da tarefa inválidos", "Título é obrigatório");
         }
-        
         if (dto.getTar_descricao() == null || dto.getTar_descricao().trim().isEmpty()) {
             throw new InvalidTaskDataException("Dados da tarefa inválidos", "Descrição é obrigatória");
         }
-        
         Optional<TarefaModel> tarefaExistente = tarefaService.buscarPorId(tar_id);
-        //busca no banco uma tarefa pelo id que vai ser opcional (pode ou nao existir)
         if (tarefaExistente.isPresent()) {
             TarefaModel t = tarefaExistente.get();
             t.setTar_titulo(dto.getTar_titulo());
@@ -99,20 +124,25 @@ public class TarefaController {
             t.setTar_prazo(dto.getTar_prazo());
             t.setTar_dataCriacao(dto.getTar_dataCriacao());
             t.setTar_dataAtualizacao(dto.getTar_dataAtualizacao());
-            t.setUsu_id(dto.getUsu_id());
-            t.setUsu_nome(dto.getUsu_nome());
+
+            // AJUSTADO: Usar o usuário logado em vez do que vem do frontend
+            if (usuarioLogado != null) {
+                t.setUsu_id(usuarioLogado.getUsu_id());
+                t.setUsu_nome(usuarioLogado.getUsu_nome());
+            }
+
             t.setProj_id(dto.getProj_id());
             t.setProj_nome(dto.getProj_nome());
             tarefaService.salvar(t);
             return ResponseEntity.ok("Tarefa atualizada com sucesso!");
         } else {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body("Tarefa não encontrada");
+                    .body("Tarefa não encontrada");
         }
     }
 
     @DeleteMapping("/apagar/{tar_id}")
-    public ResponseEntity<String> apagarTarefa(@PathVariable String tar_id) { //enqnt o path so o id ? 
+    public ResponseEntity<String> apagarTarefa(@PathVariable String tar_id) {
         Optional<TarefaModel> tarefaExistente = tarefaService.buscarPorId(tar_id);
         if (tarefaExistente.isPresent()){
             tarefaService.deletar(tar_id);
@@ -120,8 +150,7 @@ public class TarefaController {
         }
         else {
             return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body("Tarefa não encontrada");
-
+                    .body("Tarefa não encontrada");
         }
     }
 }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/AdicionadorLinkProjetos.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/AdicionadorLinkProjetos.java
@@ -9,29 +9,33 @@ import com.taskmanager.taskmngr_backend.controller.ProjetoController;
 import com.taskmanager.taskmngr_backend.model.dto.ProjetoDTO;
 
 @Component
-public class AdicionadorLinkProjetos{
+public class AdicionadorLinkProjetos {
 
     public void adicionarLink(ProjetoDTO dto) {
-        String id = dto.getProj_nome();
+
+        String id = dto.getProj_id();
+
         Link selfLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).buscarPorId(id))
-            .withSelfRel();
+                .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).buscarPorId(id))
+                .withSelfRel();
 
         Link cadastrarLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).cadastrarProjeto(dto))
-            .withRel("cadastrar");
+
+                .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).cadastrarProjeto(dto, null))
+                .withRel("cadastrar");
 
         Link allLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).listarTodas())
-            .withRel("listar");
+
+                .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).listarTodas())
+                .withRel("listar");
 
         Link updateLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).atualizar(id, dto))
-            .withRel("atualizar");
+                .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).atualizar(id, dto))
+                .withRel("atualizar");
 
         Link deleteLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).apagarProjeto(id))
-            .withRel("excluir");
+                .linkTo(WebMvcLinkBuilder.methodOn(ProjetoController.class).apagarProjeto(id))
+                .withRel("excluir");
 
         dto.add(selfLink, cadastrarLink, allLink, updateLink, deleteLink);
     }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/AdicionadorLinkTarefa.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/AdicionadorLinkTarefa.java
@@ -15,24 +15,24 @@ public class AdicionadorLinkTarefa {
         String id = dto.getTar_id();
 
         Link selfLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).buscarPorId(id))
-            .withSelfRel();
+                .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).buscarPorId(id))
+                .withSelfRel();
 
         Link cadastrarLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).cadastrarTarefa(dto))
-            .withRel("cadastrar");
+                .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).cadastrarTarefa(dto, null))
+                .withRel("cadastrar");
 
         Link allLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).listarTarefa())
-            .withRel("listar");
+                .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).listarTarefa())
+                .withRel("listar");
 
         Link updateLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).atualizarTarefa(id, dto))
-            .withRel("atualizar");
+                .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).atualizarTarefa(id, dto, null))
+                .withRel("atualizar");
 
         Link deleteLink = WebMvcLinkBuilder
-            .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).apagarTarefa(id))
-            .withRel("excluir");
+                .linkTo(WebMvcLinkBuilder.methodOn(TarefaController.class).apagarTarefa(id))
+                .withRel("excluir");
 
         dto.add(selfLink, cadastrarLink, allLink, updateLink, deleteLink);
     }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/ColunaModel.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/ColunaModel.java
@@ -2,14 +2,14 @@ package com.taskmanager.taskmngr_backend.model;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
-
 import lombok.Data;
 
-@Document
+@Document(collection = "colunas")
 @Data
 public class ColunaModel {
     @Id
     private String colId;
     private String colTitulo;
     private Integer colOrdem;
+    private String proj_id;
 }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/ProjetoModel.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/ProjetoModel.java
@@ -1,7 +1,11 @@
 package com.taskmanager.taskmngr_backend.model;
 
-import org.springframework.data.annotation.Id;
+import java.util.List;
 
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "projetos")
 public class ProjetoModel {
     @Id
     private String proj_id;
@@ -12,6 +16,8 @@ public class ProjetoModel {
     private String proj_dataAtualizacao;
     private String equ_id;
     private String equ_nome;
+
+    private List<String> usuarioIds;
 
     public String getProj_id() {return proj_id;}
     public void setProj_id(String proj_id) {this.proj_id = proj_id;}
@@ -36,5 +42,8 @@ public class ProjetoModel {
 
     public String getEqu_nome() {return equ_nome;}
     public void setEqu_nome(String equ_nome) {this.equ_nome = equ_nome;}
+
+    public List<String> getUsuarioIds() {return usuarioIds;}
+    public void setUsuarioIds(List<String> usuarioIds) {this.usuarioIds = usuarioIds;}
 
 }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/dto/ColunaDTO.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/model/dto/ColunaDTO.java
@@ -13,4 +13,5 @@ public class ColunaDTO extends RepresentationModel<ColunaDTO>{
     private String Id;
     private String Titulo;
     private Integer Ordem;
+    private String proj_id;
 }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/repository/ColunaRepository.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/repository/ColunaRepository.java
@@ -1,11 +1,14 @@
 package com.taskmanager.taskmngr_backend.repository;
 
 import java.util.List;
-
 import org.springframework.data.mongodb.repository.MongoRepository;
-
+import org.springframework.data.mongodb.repository.Query;
 import com.taskmanager.taskmngr_backend.model.ColunaModel;
 
-public interface ColunaRepository extends MongoRepository<ColunaModel, String>{
-    List<ColunaModel>findAllByOrderByColOrdemAsc();
+public interface ColunaRepository extends MongoRepository<ColunaModel, String> {
+    @Query(value="{ 'proj_id' : ?0 }", sort="{ 'colOrdem' : 1 }")
+    List<ColunaModel> findByProjIdOrderByColOrdemAsc(String proj_id);
+
+    @Query(value="{ 'proj_id' : ?0 }", count = true)
+    long countByProj_id(String proj_id);
 }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/repository/ProjetoRepository.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/repository/ProjetoRepository.java
@@ -4,6 +4,10 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 
 import com.taskmanager.taskmngr_backend.model.ProjetoModel;
 
+import java.util.List;
+
 public interface ProjetoRepository extends MongoRepository<ProjetoModel, String> {
+
+    List<ProjetoModel> findByUsuarioIdsContaining(String usuarioId);
 
 }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/repository/TarefaRepository.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/repository/TarefaRepository.java
@@ -1,8 +1,15 @@
 package com.taskmanager.taskmngr_backend.repository;
 
+import java.util.List;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import com.taskmanager.taskmngr_backend.model.TarefaModel;
 
 public interface TarefaRepository extends MongoRepository<TarefaModel, String> {
 
+    @Query("{ 'proj_id': { '$in': ?0 } }")
+    List<TarefaModel> findByProjIdIn(List<String> projetoIds);
+
+    @Query("{ 'proj_id': ?0 }")
+    List<TarefaModel> findByProjId(String projId);
 }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/service/ColunaService.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/service/ColunaService.java
@@ -2,53 +2,56 @@ package com.taskmanager.taskmngr_backend.service;
 
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
+import com.taskmanager.taskmngr_backend.exceptions.personalizados.projetos.ProjetoNaoEncontradoException; // Usando uma exceção mais apropriada
 import com.taskmanager.taskmngr_backend.model.ColunaModel;
 import com.taskmanager.taskmngr_backend.model.dto.ColunaDTO;
 import com.taskmanager.taskmngr_backend.repository.ColunaRepository;
 
 @Service
 public class ColunaService {
-    
+
     @Autowired
     private ColunaRepository colunaRepository;
 
-    public List<ColunaDTO> listarTodas() {
-        List<ColunaModel> colunas = colunaRepository.findAllByOrderByColOrdemAsc();
+    // MÉTODO MODIFICADO: Agora lista colunas por ID de projeto
+    public List<ColunaDTO> listarPorProjeto(String proj_id) {
+        List<ColunaModel> colunas = colunaRepository.findByProjIdOrderByColOrdemAsc(proj_id);
         return colunas.stream()
-                .map(c -> new ColunaDTO(c.getColId(), c.getColTitulo(), c.getColOrdem()))
+                .map(c -> new ColunaDTO(c.getColId(), c.getColTitulo(), c.getColOrdem(), c.getProj_id()))
                 .collect(Collectors.toList());
     }
+
+    // MÉTODO MODIFICADO: Agora cria a coluna associada a um projeto
     public ColunaDTO criarColuna(ColunaDTO colunaDTO) {
-        long totalColunas = colunaRepository.count();
-        
+        // A contagem agora é específica do projeto
+        long totalColunasNoProjeto = colunaRepository.countByProj_id(colunaDTO.getProj_id());
+
         ColunaModel novaColuna = new ColunaModel();
         novaColuna.setColTitulo(colunaDTO.getTitulo());
-        novaColuna.setColOrdem((int) totalColunas);
-        
+        novaColuna.setProj_id(colunaDTO.getProj_id()); // Salva o ID do projeto
+        novaColuna.setColOrdem((int) totalColunasNoProjeto);
+
         ColunaModel colunaSalva = colunaRepository.save(novaColuna);
-        
-        return new ColunaDTO(colunaSalva.getColId(), colunaSalva.getColTitulo(), colunaSalva.getColOrdem());
+
+        return new ColunaDTO(colunaSalva.getColId(), colunaSalva.getColTitulo(), colunaSalva.getColOrdem(), colunaSalva.getProj_id());
     }
 
     public ColunaDTO atualizarColuna(String col_id, ColunaDTO colunaDTO) {
         ColunaModel colunaExistente = colunaRepository.findById(col_id)
-                .orElseThrow(() -> new UsernameNotFoundException("Coluna não encontrada com id: " + col_id));
+                .orElseThrow(() -> new ProjetoNaoEncontradoException("Coluna não encontrada", "Coluna com id " + col_id + " não foi encontrada"));
 
         colunaExistente.setColTitulo(colunaDTO.getTitulo());
-        
+
         ColunaModel colunaAtualizada = colunaRepository.save(colunaExistente);
-        
-        return new ColunaDTO(colunaAtualizada.getColId(), colunaAtualizada.getColTitulo(), colunaAtualizada.getColOrdem());
+
+        return new ColunaDTO(colunaAtualizada.getColId(), colunaAtualizada.getColTitulo(), colunaAtualizada.getColOrdem(), colunaAtualizada.getProj_id());
     }
 
     public void deletarColuna(String col_id) {
         if (!colunaRepository.existsById(col_id)) {
-            throw new UsernameNotFoundException("Coluna não encontrada com id: " + col_id);
+            throw new ProjetoNaoEncontradoException("Coluna não encontrada", "Coluna com id " + col_id + " não foi encontrada");
         }
         colunaRepository.deleteById(col_id);
     }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/service/DataInitializer.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/service/DataInitializer.java
@@ -18,30 +18,31 @@ public class DataInitializer implements CommandLineRunner {
     private ColunaRepository colunaRepository;
 
     @Override
-    public void run(String... args) throws Exception {  
-        if (colunaRepository.count() == 0) {
-            System.out.println("Nenhuma coluna encontrada, criando colunas padrão...");
-
-            // Cria as três colunas padrão
-            ColunaModel pendente = new ColunaModel();
-            pendente.setColTitulo("Pendente");
-            pendente.setColOrdem(0);
-
-            ColunaModel emDesenvolvimento = new ColunaModel();
-            emDesenvolvimento.setColTitulo("Em Desenvolvimento");
-            emDesenvolvimento.setColOrdem(1);
-
-            ColunaModel concluida = new ColunaModel();
-            concluida.setColTitulo("Concluída");
-            concluida.setColOrdem(2);
-
-            List<ColunaModel> colunasPadrao = Arrays.asList(pendente, emDesenvolvimento, concluida);
-
-            colunaRepository.saveAll(colunasPadrao);
-
-            System.out.println("Colunas padrão criadas com sucesso!");
-        } else {
-            System.out.println("Colunas já existem no banco de dados. Nenhuma ação necessária.");
-        }
+    public void run(String... args) throws Exception {
+        System.out.println("DataInitializer desativado. Colunas agora são criadas por projeto.");
+//        if (colunaRepository.count() == 0) {
+//            System.out.println("Nenhuma coluna encontrada, criando colunas padrão...");
+//
+//            // Cria as três colunas padrão
+//            ColunaModel pendente = new ColunaModel();
+//            pendente.setColTitulo("Pendente");
+//            pendente.setColOrdem(0);
+//
+//            ColunaModel emDesenvolvimento = new ColunaModel();
+//            emDesenvolvimento.setColTitulo("Em Desenvolvimento");
+//            emDesenvolvimento.setColOrdem(1);
+//
+//            ColunaModel concluida = new ColunaModel();
+//            concluida.setColTitulo("Concluída");
+//            concluida.setColOrdem(2);
+//
+//            List<ColunaModel> colunasPadrao = Arrays.asList(pendente, emDesenvolvimento, concluida);
+//
+//            colunaRepository.saveAll(colunasPadrao);
+//
+//            System.out.println("Colunas padrão criadas com sucesso!");
+//        } else {
+//            System.out.println("Colunas já existem no banco de dados. Nenhuma ação necessária.");
+//        }
     }
 }

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/service/ProjetoService.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/service/ProjetoService.java
@@ -1,8 +1,13 @@
 package com.taskmanager.taskmngr_backend.service;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import com.taskmanager.taskmngr_backend.model.ColunaModel;
+import com.taskmanager.taskmngr_backend.model.UsuarioModel;
+import com.taskmanager.taskmngr_backend.repository.ColunaRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import com.taskmanager.taskmngr_backend.model.ProjetoModel;
@@ -13,9 +18,45 @@ public class ProjetoService {
     @Autowired
     private ProjetoRepository projetoRepository;
 
+    @Autowired
+    private ColunaRepository colunaRepository;
+
+    public ProjetoModel criarNovoProjeto(ProjetoModel projeto) {
+        ProjetoModel projetoSalvo = projetoRepository.save(projeto);
+        String novoProjetoId = projetoSalvo.getProj_id();
+
+        // Cria as três colunas padrão <<<<<<<-----------------
+        ColunaModel pendente = new ColunaModel();
+        pendente.setColTitulo("Pendente");
+        pendente.setColOrdem(0);
+        pendente.setProj_id(novoProjetoId);
+
+        ColunaModel emDesenvolvimento = new ColunaModel();
+        emDesenvolvimento.setColTitulo("Em Desenvolvimento");
+        emDesenvolvimento.setColOrdem(1);
+        emDesenvolvimento.setProj_id(novoProjetoId);
+
+        ColunaModel concluida = new ColunaModel();
+        concluida.setColTitulo("Concluída");
+        concluida.setColOrdem(2);
+        concluida.setProj_id(novoProjetoId);
+
+        List<ColunaModel> colunasPadrao = Arrays.asList(pendente, emDesenvolvimento, concluida);
+        colunaRepository.saveAll(colunasPadrao);
+
+        return projetoSalvo;
+    }
+
     public List<ProjetoModel> listarTodas() {
         return projetoRepository.findAll();
     }
+
+    public List<ProjetoModel> listarPorUsuario(UsuarioModel usuario) {
+        if (usuario == null || usuario.getUsu_id() == null) {
+            // Se não houver usuário logado, retorna uma lista vazia por segurança.
+            return Collections.emptyList();
+        }
+        return projetoRepository.findByUsuarioIdsContaining(usuario.getUsu_id());}
 
     public Optional<ProjetoModel> buscarPorId(String id) {
         return projetoRepository.findById(id);

--- a/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/service/TarefaService.java
+++ b/taskmngr-backend/taskmngr-backend/src/main/java/com/taskmanager/taskmngr_backend/service/TarefaService.java
@@ -1,11 +1,14 @@
 package com.taskmanager.taskmngr_backend.service;
 
+import com.taskmanager.taskmngr_backend.model.ProjetoModel;
 import com.taskmanager.taskmngr_backend.model.TarefaModel;
 import com.taskmanager.taskmngr_backend.repository.TarefaRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 @Service
 public class TarefaService {
@@ -15,6 +18,24 @@ public class TarefaService {
 
     public List<TarefaModel> listarTodas() {
         return tarefaRepository.findAll();
+    }
+
+    public List<TarefaModel> listarPorProjetos(List<ProjetoModel> projetos) {
+        if (projetos == null || projetos.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> projetoIds = projetos.stream()
+                .map(ProjetoModel::getProj_id)
+                .collect(Collectors.toList());
+        return tarefaRepository.findByProjIdIn(projetoIds);
+    }
+
+    // ... dentro da classe TarefaService
+    public List<TarefaModel> listarPorProjetoUnico(String projId) {
+        if (projId == null || projId.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return tarefaRepository.findByProjId(projId);
     }
 
     public Optional<TarefaModel> buscarPorId(String id) {

--- a/taskmngr-frontend/src/components/BarraLateralProjetos.tsx
+++ b/taskmngr-frontend/src/components/BarraLateralProjetos.tsx
@@ -1,252 +1,287 @@
 import React from "react";
-import ModalEditarProjetos from './ModalEditarProjetos';
+import ModalEditarProjetos from "./ModalEditarProjetos";
+import { authFetch } from "../utils/api";
 
 export interface Projeto {
-    id: string;
-    nome: string;
-    descricao?: string;
-    dataCriacao?: string;
+  id: string;
+  nome: string;
+  descricao?: string;
+  dataCriacao?: string;
 }
 
 interface BarraLateralProjetosProps {
-    projetos: Projeto[];
-    onOpenModal: () => void;
-    activeProjectId?: string | number; 
+  onOpenModal: () => void;
+  onProjectSelect: (projectId: string | null) => void;
 }
 
 interface BarraLateralProjetosState {
-    activeProjectId: string | null;
-    projetos: Projeto[];
-    optionsProjectId: string | null;
-    isDeleting: boolean;
-    optionsMenuPos: { top: number; left: number } | null; 
-    isEditModalOpen: boolean;
-    projetoParaEditar: Projeto | null;
+  activeProjectId: string | null;
+  projetos: Projeto[];
+  optionsProjectId: string | null;
+  isDeleting: boolean;
+  optionsMenuPos: { top: number; left: number } | null;
+  isEditModalOpen: boolean;
+  projetoParaEditar: Projeto | null;
 }
 
-export default class BarraLateralProjetos extends React.Component<BarraLateralProjetosProps, BarraLateralProjetosState> {
-    constructor(props: BarraLateralProjetosProps) {
-        super(props);
-        this.state = {
-            activeProjectId: null,
-            projetos: [],
-            optionsProjectId: null,
-            isDeleting: false,
-            optionsMenuPos: null,
-            isEditModalOpen: false,
-            projetoParaEditar: null,
-        };
-    }
 
-    private handleProjetoCreated = () => {
-        this.fetchProjetos();
+export default class BarraLateralProjetos extends React.Component<
+  BarraLateralProjetosProps,
+  BarraLateralProjetosState
+> {
+  constructor(props: BarraLateralProjetosProps) {
+    super(props);
+    this.state = {
+      activeProjectId: null,
+      projetos: [],
+      optionsProjectId: null,
+      isDeleting: false,
+      optionsMenuPos: null,
+      isEditModalOpen: false,
+      projetoParaEditar: null,
     };
+  }
 
-    async componentDidMount() {
-        window.addEventListener('projeto:created', this.handleProjetoCreated);
-        await this.fetchProjetos();
-    }
+  private handleProjetoCreated = () => {
+    this.fetchProjetos();
+  };
 
-    componentWillUnmount(): void {
-        window.removeEventListener('projeto:created', this.handleProjetoCreated);
-    }
+  async componentDidMount() {
+    window.addEventListener("projeto:created", this.handleProjetoCreated);
+    await this.fetchProjetos();
+  }
 
-    fetchProjetos = async () => {
-        try {
-            const response = await fetch("http://localhost:8080/projeto/listar");
-            if (!response.ok) throw new Error("Erro ao buscar projetos");
-            const data = await response.json();
+  componentWillUnmount(): void {
+    window.removeEventListener("projeto:created", this.handleProjetoCreated);
+  }
 
-            type BackendProjeto = {
-                proj_id?: string | number; id?: string | number;
-                proj_nome?: string; nome?: string;
-                proj_descricao?: string; descricao?: string;
-                proj_dataCriacao?: string; dataCriacao?: string;
-            };
+  fetchProjetos = async () => {
+    try {
+      const response = await authFetch(
+        "http://localhost:8080/projeto/meus-projetos"
+      );
+      if (!response.ok) throw new Error("Erro ao buscar projetos");
+      const data = await response.json();
 
-            const normalized: Projeto[] = Array.isArray(data)
-                ? data.map((d: BackendProjeto) => ({
-                    id: String(d.proj_id ?? d.id ?? ""),
-                    nome: String(d.proj_nome ?? d.nome ?? ""),
-                    descricao: String(d.proj_descricao ?? d.descricao ?? ""),
-                    dataCriacao: String(d.proj_dataCriacao ?? d.dataCriacao ?? ""),
-                }))
-                : [];
+      const normalized: Projeto[] = (Array.isArray(data) ? data : []).map(
+        
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (d: any) => ({
+          id: String(d.proj_id ?? d.id ?? ""),
+          nome: String(d.proj_nome ?? d.nome ?? ""),
+          descricao: String(d.proj_descricao ?? d.descricao ?? ""),
+          dataCriacao: String(d.proj_dataCriacao ?? d.dataCriacao ?? ""),
+        })
+      );
 
-            this.setState(prev => ({
-                projetos: normalized,
-                activeProjectId: prev.activeProjectId ?? (normalized.length ? normalized[0].id : null)
-            }));
-        } catch (error) {
-            console.error(error);
+      this.setState({ projetos: normalized }, () => {
+        
+        if (normalized.length > 0 && !this.state.activeProjectId) {
+          this.handleProjectClick(normalized[0].id);
+        } else if (normalized.length === 0) {
+          this.props.onProjectSelect(null);
         }
-    };
+      });
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
-    handleSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        await this.fetchProjetos();
-    };
+  handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await this.fetchProjetos();
+  };
 
-    // Agora abre o modal direto ao clicar no projeto
-    handleProjectClick = (projectId: string) => {
-        this.setState({
-            activeProjectId: projectId
-        });
-    };
+  handleProjectClick = (projectId: string) => {
+    this.setState({
+      activeProjectId: projectId,
+    });
+    this.props.onProjectSelect(projectId);
+  };
 
-    openOptions = (e: React.MouseEvent, projectId: string) => {
-        e.stopPropagation();
-        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-        const top = rect.top + window.scrollY + rect.height / 2;
-        const left = rect.left + window.scrollX;
-        this.setState({ optionsProjectId: projectId, optionsMenuPos: { top, left } });
-    };
+  openOptions = (e: React.MouseEvent, projectId: string) => {
+    e.stopPropagation();
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const top = rect.top + window.scrollY + rect.height / 2;
+    const left = rect.left + window.scrollX;
+    this.setState({
+      optionsProjectId: projectId,
+      optionsMenuPos: { top, left },
+    });
+  };
 
-    closeOptions = () => {
-        this.setState({ optionsProjectId: null, optionsMenuPos: null });
-    };
+  closeOptions = () => {
+    this.setState({ optionsProjectId: null, optionsMenuPos: null });
+  };
 
-    handleEdit = () => {
-        const { optionsProjectId, projetos } = this.state;
-        if (!optionsProjectId) return;
-        const projeto = projetos.find(p => p.id === optionsProjectId) ?? null;
-        this.setState({ projetoParaEditar: projeto, isEditModalOpen: true });
-        this.closeOptions();
-    };
+  handleEdit = () => {
+    const { optionsProjectId, projetos } = this.state;
+    if (!optionsProjectId) return;
+    const projeto = projetos.find((p) => p.id === optionsProjectId) ?? null;
+    this.setState({ projetoParaEditar: projeto, isEditModalOpen: true });
+    this.closeOptions();
+  };
 
-    closeEditModal = () => {
-        this.setState({ isEditModalOpen: false, projetoParaEditar: null });
-    };
+  closeEditModal = () => {
+    this.setState({ isEditModalOpen: false, projetoParaEditar: null });
+  };
 
-    handleProjetoSalvo = () => {
-        this.fetchProjetos();
-        this.closeEditModal();
-    };
+  handleProjetoSalvo = () => {
+    this.fetchProjetos();
+    this.closeEditModal();
+  };
 
-    handleDelete = async () => {
+ handleDelete = async () => {
         const { optionsProjectId } = this.state;
         if (!optionsProjectId) return;
 
         try {
             this.setState({ isDeleting: true });
-            const resp = await fetch(`http://localhost:8080/projeto/apagar/${encodeURIComponent(optionsProjectId)}`, { method: 'DELETE' });
+            
+            const resp = await authFetch(`http://localhost:8080/projeto/apagar/${encodeURIComponent(optionsProjectId)}`, { method: 'DELETE' });
             if (!resp.ok) {
-                const text = await resp.text();
-                throw new Error(`Falha ao excluir: ${resp.status} ${resp.statusText} - ${text}`);
+                throw new Error(`Falha ao excluir`);
+            }
+            
+            if (this.state.activeProjectId === optionsProjectId) {
+                this.props.onProjectSelect(null);
+                this.setState({ activeProjectId: null });
             }
             await this.fetchProjetos();
             this.closeOptions();
         } catch (err) {
             console.error(err);
-            console.log('Não foi possível excluir o projeto.');
         } finally {
             this.setState({ isDeleting: false });
         }
     };
 
-    render() {
-        const { onOpenModal } = this.props;
-        const { projetos, optionsProjectId, optionsMenuPos, isDeleting, isEditModalOpen, projetoParaEditar } = this.state;
+  render() {
+    const { onOpenModal } = this.props;
+    const {
+      projetos,
+      optionsProjectId,
+      optionsMenuPos,
+      isDeleting,
+      isEditModalOpen,
+      projetoParaEditar,
+    } = this.state;
 
-        return (
-            <div className="h-full w-64 bg-white border-r border-slate-200 flex flex-col">
-                <div className="p-4 border-b border-slate-200">
-                    <div className="flex items-center gap-3">
-                        <i className="fa-solid fa-folder-open text-indigo-600 text-2xl"></i>
-                        <h2 className="text-xl font-bold text-slate-800">Projetos</h2>
-                    </div>
-                </div>
-                <div className="p-4">
-                    <div className="flex justify-between items-center mb-4 pb-3">
-                        <h1 className="font-bold text-slate-500 text-sm tracking-wider uppercase">Workspaces</h1>
-                        <button 
-                            onClick={onOpenModal} 
-                            className="flex items-center gap-1 text-indigo-600 hover:text-indigo-800 font-semibold text-sm transition-colors group bg-indigo-100 hover:bg-indigo-200 rounded-md px-1.5"
-                        >
-                            <i className="fa-solid fa-plus bg-indigo-100 group-hover:bg-indigo-200 rounded-full"></i>
-                            <span>Add</span>
-                        </button>
-                    </div>
-                    <div className="flex flex-col gap-1">
-                        {projetos.map((p) => {
-                            const isActive = this.state.activeProjectId === p.id;
-                            return (
-                                <div 
-                                    key={p.id}
-                                    onClick={() => this.handleProjectClick(p.id)}
-                                    className={`
+    return (
+      <div className="h-full w-64 bg-white border-r border-slate-200 flex flex-col">
+        <div className="p-4 border-b border-slate-200">
+          <div className="flex items-center gap-3">
+            <i className="fa-solid fa-folder-open text-indigo-600 text-2xl"></i>
+            <h2 className="text-xl font-bold text-slate-800">Projetos</h2>
+          </div>
+        </div>
+        <div className="p-4">
+          <div className="flex justify-between items-center mb-4 pb-3">
+            <h1 className="font-bold text-slate-500 text-sm tracking-wider uppercase">
+              Workspaces
+            </h1>
+            <button
+              onClick={onOpenModal}
+              className="flex items-center gap-1 text-indigo-600 hover:text-indigo-800 font-semibold text-sm transition-colors group bg-indigo-100 hover:bg-indigo-200 rounded-md px-1.5"
+            >
+              <i className="fa-solid fa-plus bg-indigo-100 group-hover:bg-indigo-200 rounded-full"></i>
+              <span>Add</span>
+            </button>
+          </div>
+          <div className="flex flex-col gap-1">
+            {projetos.map((p) => {
+              const isActive = this.state.activeProjectId === p.id;
+              return (
+                <div
+                  key={p.id}
+                  onClick={() => this.handleProjectClick(p.id)}
+                  className={`
                                         flex items-center justify-between w-full rounded-md p-2 text-md cursor-pointer transition-all duration-150
-                                        ${isActive 
-                                            ? 'bg-indigo-100 text-indigo-700 font-bold' 
-                                            : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'
+                                        ${
+                                          isActive
+                                            ? "bg-indigo-100 text-indigo-700 font-bold"
+                                            : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
                                         }
                                     `}
-                                >
-                                    <div className="flex items-center gap-2">
-                                        <span className={`
+                >
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={`
                                             w-1.5 h-1.5 rounded-full
-                                            ${isActive ? 'bg-indigo-500' : 'bg-slate-300 group-hover:bg-slate-400'}
-                                        `}></span>
-                                        <p className="leading-none">{p.nome}</p>
-                                    </div>
-                                    <i
-                                        role="button"
-                                        aria-label="Mais opções"
-                                        title="Mais opções"
-                                        tabIndex={0}
-                                        onClick={(e) => this.openOptions(e, p.id)}
-                                        className={`
-                                            fa-solid fa-ellipsis-vertical cursor-pointer p-0 rounded-full
-                                            ${isActive ? 'text-indigo-600' : 'text-slate-400 hover:bg-slate-200'}
+                                            ${
+                                              isActive
+                                                ? "bg-indigo-500"
+                                                : "bg-slate-300 group-hover:bg-slate-400"
+                                            }
                                         `}
-                                    ></i>
-                                </div>
-                            );
-                        })}
-                    </div>
+                    ></span>
+                    <p className="leading-none">{p.nome}</p>
+                  </div>
+                  <i
+                    role="button"
+                    aria-label="Mais opções"
+                    title="Mais opções"
+                    tabIndex={0}
+                    onClick={(e) => this.openOptions(e, p.id)}
+                    className={`
+                                            fa-solid fa-ellipsis-vertical cursor-pointer p-0 rounded-full
+                                            ${
+                                              isActive
+                                                ? "text-indigo-600"
+                                                : "text-slate-400 hover:bg-slate-200"
+                                            }
+                                        `}
+                  ></i>
                 </div>
+              );
+            })}
+          </div>
+        </div>
 
-                {optionsProjectId && optionsMenuPos && (
-                    <>
-                        <div className="fixed inset-0 z-40" onClick={this.closeOptions}></div>
+        {optionsProjectId && optionsMenuPos && (
+          <>
+            <div
+              className="fixed inset-0 z-40"
+              onClick={this.closeOptions}
+            ></div>
 
-                        <div
-                            className="fixed z-50 bg-white border border-slate-200 rounded-md shadow-lg w-44 p-2"
-                            style={{
-                                top: optionsMenuPos.top,
-                                left: optionsMenuPos.left,
-                                transform: 'translate(calc(-100% - 6px), -50%)'
-                            }}
-                            onClick={(e) => e.stopPropagation()}
-                        >
-                            <button
-                                onClick={this.handleEdit}
-                                className="w-full text-left px-3 py-2 rounded hover:bg-slate-100 flex items-center gap-2"
-                            >
-                                <i className="fa-solid fa-pen text-slate-600"></i>
-                                <span>Editar</span>
-                            </button>
-                            <button
-                                onClick={this.handleDelete}
-                                disabled={isDeleting}
-                                className="w-full text-left px-3 py-2 rounded hover:bg-red-50 text-red-700 flex items-center gap-2 disabled:opacity-60"
-                            >
-                                <i className="fa-solid fa-trash"></i>
-                                <span>{isDeleting ? 'Excluindo...' : 'Excluir'}</span>
-                            </button>
-                        </div>
-                    </>
-                )}
-
-                {isEditModalOpen && projetoParaEditar && (
-                    <ModalEditarProjetos
-                        isOpen={isEditModalOpen}
-                        onClose={this.closeEditModal}
-                        projeto={projetoParaEditar}
-                        onSaved={this.handleProjetoSalvo}
-                    />
-                )}
+            <div
+              className="fixed z-50 bg-white border border-slate-200 rounded-md shadow-lg w-44 p-2"
+              style={{
+                top: optionsMenuPos.top,
+                left: optionsMenuPos.left,
+                transform: "translate(calc(-100% - 6px), -50%)",
+              }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                onClick={this.handleEdit}
+                className="w-full text-left px-3 py-2 rounded hover:bg-slate-100 flex items-center gap-2"
+              >
+                <i className="fa-solid fa-pen text-slate-600"></i>
+                <span>Editar</span>
+              </button>
+              <button
+                onClick={this.handleDelete}
+                disabled={isDeleting}
+                className="w-full text-left px-3 py-2 rounded hover:bg-red-50 text-red-700 flex items-center gap-2 disabled:opacity-60"
+              >
+                <i className="fa-solid fa-trash"></i>
+                <span>{isDeleting ? "Excluindo..." : "Excluir"}</span>
+              </button>
             </div>
-        )
-    }
+          </>
+        )}
+
+        {isEditModalOpen && projetoParaEditar && (
+          <ModalEditarProjetos
+            isOpen={isEditModalOpen}
+            onClose={this.closeEditModal}
+            projeto={projetoParaEditar}
+            onSaved={this.handleProjetoSalvo}
+          />
+        )}
+      </div>
+    );
+  }
 }

--- a/taskmngr-frontend/src/components/ModalProjetos.tsx
+++ b/taskmngr-frontend/src/components/ModalProjetos.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { authFetch } from '../utils/api'
 
 type NovoProjeto = {
   nome: string;
@@ -55,7 +56,7 @@ export default class ModalProjetos extends React.Component<ModalProps, ModalStat
 
   adicionarProjeto = async () => {
     try {
-        const response = await fetch("http://localhost:8080/projeto/cadastrar", {
+        const response = await authFetch("http://localhost:8080/projeto/cadastrar", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
@@ -163,7 +164,7 @@ export default class ModalProjetos extends React.Component<ModalProps, ModalStat
               </div>
             </div> */}
 
-            <div>
+            {/* <div>
               <label htmlFor="team" className="block text-sm font-medium text-gray-700 mb-1">Equipe</label>
               <select
                 id="team"
@@ -177,7 +178,7 @@ export default class ModalProjetos extends React.Component<ModalProps, ModalStat
                 <option>GeneSys</option>
                 <option>Fatec</option>
               </select>
-            </div>
+            </div> */}
 
             <div className="flex justify-center mt-6">
               <button

--- a/taskmngr-frontend/src/components/layout/LayoutPrincipal.tsx
+++ b/taskmngr-frontend/src/components/layout/LayoutPrincipal.tsx
@@ -1,97 +1,83 @@
-import { Component } from "react";
+import { useState } from "react";
 import { Outlet, Link } from "react-router-dom";
 
 import NavbarPrincipal from "../headers/NavbarPrincipal";
 import BarraLateral from "../BarraLateral";
-import BarraLateralProjetos, { type Projeto } from "../BarraLateralProjetos";
+import BarraLateralProjetos from "../BarraLateralProjetos";
 import NavbarProjetos from "../NavbarProjetos";
 import ModalProjetos from "../ModalProjetos";
 
-
-interface LayoutState {
-  projetos: Projeto[];
-  isModalOpen: boolean;
-  isSidebarOpen: boolean;
-}
-
-// eslint-disable-next-line react-refresh/only-export-components
 const BottomNavbar = () => (
   <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-indigo-950 shadow-lg z-30">
     <div className="flex justify-around items-center h-16">
-      <Link className="flex-1 flex justify-center p-2" to="/home"><i className="fa-solid fa-house text-2xl text-white"></i></Link>
-      <Link className="flex-1 flex justify-center p-2" to="/equipes"><i className="fa-solid fa-people-group text-2xl text-white"></i></Link>
-      <Link className="flex-1 flex justify-center p-2" to="/calendario"><i className="fa-solid fa-calendar text-2xl text-white"></i></Link>
-      <Link className="flex-1 flex justify-center p-2" to="/info"><i className="fa-solid fa-info-circle text-2xl text-white"></i></Link>
+      <Link className="flex-1 flex justify-center p-2" to="/home">
+        <i className="fa-solid fa-house text-2xl text-white"></i>
+      </Link>
+      <Link className="flex-1 flex justify-center p-2" to="/equipes">
+        <i className="fa-solid fa-people-group text-2xl text-white"></i>
+      </Link>
+      <Link className="flex-1 flex justify-center p-2" to="/calendario">
+        <i className="fa-solid fa-calendar text-2xl text-white"></i>
+      </Link>
+      <Link className="flex-1 flex justify-center p-2" to="/info">
+        <i className="fa-solid fa-info-circle text-2xl text-white"></i>
+      </Link>
     </div>
   </div>
 );
 
-export default class LayoutPrincipal extends Component<object, LayoutState> {
-  state = {
-    projetos: [],
-    isModalOpen: false,
-    isSidebarOpen: false,
-  };
+export default function LayoutPrincipal() {
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
-  handleOpenModal = () => this.setState({ isModalOpen: true });
-  handleCloseModal = () => this.setState({ isModalOpen: false });
+  const [isModalProjetosOpen, setIsModalProjetosOpen] = useState(false);
 
-  handleAddProject = (novoProjeto: { nome: string }) => {
-    this.setState((prevState) => ({
-      projetos: [
-        ...prevState.projetos,
-        { id: Date.now().toString(), nome: novoProjeto.nome },
-      ],
-      isModalOpen: false,
-    }));
-  };
-  toggleSidebar = () => {
-    this.setState((prevState) => ({ isSidebarOpen: !prevState.isSidebarOpen }));
-  };
+  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(
+    null
+  );
 
-  render() {
-    return (
-      <div className="bg-slate-50 h-screen flex flex-col">
-        <NavbarPrincipal onToggleSidebar={this.toggleSidebar} />
+  const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
 
-        <div className="flex flex-1 overflow-hidden">
-          <div className="hidden lg:block">
-            <BarraLateral />
-          </div>
-          <div className={`
+  const handleOpenModal = () => setIsModalProjetosOpen(true);
+  const handleCloseModal = () => setIsModalProjetosOpen(false);
+
+  return (
+    <div className="bg-slate-50 h-screen flex flex-col">
+      <NavbarPrincipal onToggleSidebar={toggleSidebar} />
+
+      <div className="flex flex-1 overflow-hidden">
+        <div className="hidden lg:block">
+          <BarraLateral />
+        </div>
+        <div
+          className={`
             fixed lg:static top-0 left-0 h-full z-20 transition-transform duration-300 ease-in-out
-            ${this.state.isSidebarOpen ? 'translate-x-0' : '-translate-x-full'} 
-            lg:translate-x-0`
-          }>
-            <BarraLateralProjetos 
-                projetos={this.state.projetos} 
-                onOpenModal={this.handleOpenModal} 
-            />
+            ${isSidebarOpen ? "translate-x-0" : "-translate-x-full"} 
+            lg:translate-x-0`}
+        >
+          <BarraLateralProjetos
+            onOpenModal={handleOpenModal}
+            onProjectSelect={setSelectedProjectId}
+          />
         </div>
 
-        {this.state.isSidebarOpen && (
-            <div 
-                className="fixed inset-0 bg-black/50 z-10 lg:hidden"
-                onClick={this.toggleSidebar}
-            ></div>
+        {isSidebarOpen && (
+          <div
+            className="fixed inset-0 bg-black/50 z-10 lg:hidden"
+            onClick={toggleSidebar}
+          ></div>
         )}
 
-          <div className="p-2 md:p-4 flex-1 flex flex-col min-w-0 h-full">
-            <NavbarProjetos />
+        <div className="p-2 md:p-4 flex-1 flex flex-col min-w-0 h-full">
+          <NavbarProjetos />
 
-            <Outlet />
-          </div>
+          <Outlet context={{ selectedProjectId }} />
         </div>
-
-        <ModalProjetos
-          isOpen={this.state.isModalOpen}
-          onClose={this.handleCloseModal}
-          onAddProject={this.handleAddProject}
-        />
-        
-        <BottomNavbar />
       </div>
-    );
-  }
-}
 
+      {/* CORRIGIDO: Renderizando o ModalProjetos com as props que ele espera */}
+      <ModalProjetos isOpen={isModalProjetosOpen} onClose={handleCloseModal} />
+
+      <BottomNavbar />
+    </div>
+  );
+}

--- a/taskmngr-frontend/src/utils/api.tsx
+++ b/taskmngr-frontend/src/utils/api.tsx
@@ -1,0 +1,25 @@
+export async function authFetch(url: string, options: RequestInit = {}): Promise<Response> {
+    const token = localStorage.getItem('token');
+    const headers = new Headers(options.headers || {});
+
+    if (token) {
+        headers.append('Authorization', `Bearer ${token}`);
+    }
+
+    if (options.body && !headers.has('Content-Type')) {
+        headers.append('Content-Type', 'application/json');
+    }
+
+    const response = await fetch(url, {
+        ...options,
+        headers: headers,
+    });
+
+    if (response.status === 401) {
+        localStorage.removeItem('token');
+        window.location.href = '/login';
+        throw new Error('Sessão expirada. Por favor, faça login novamente.');
+    }
+
+    return response;
+}


### PR DESCRIPTION
Este commit refatora a aplicação para que cada projeto tenha suas próprias colunas e tarefas, visíveis apenas para os usuários associados.

- Backend:
  - Colunas e Tarefas agora são vinculadas a Projetos através de um 'proj_id'.
  - Projetos são vinculados a Usuários.
  - Criados novos endpoints para buscar dados por projeto (ex: '/colunas/por-projeto/{id}').
  - Adicionada funcionalidade que cria 3 colunas padrão para cada novo projeto.

- Frontend:
  - A barra lateral agora lista apenas os projetos do usuário autenticado.
  - O quadro Kanban se torna dinâmico, exibindo apenas as colunas e tarefas do projeto selecionado.
  - Todas as chamadas para a API agora são autenticadas.